### PR TITLE
Adds the thread_only check to the tag command.

### DIFF
--- a/tagging/tagging.py
+++ b/tagging/tagging.py
@@ -15,6 +15,7 @@ class Tagging(commands.Cog):
 
     @checks.has_permissions(PermissionLevel.SUPPORTER)
     @commands.command()
+    @checks.thread_only()
     async def tag(self, ctx: commands.Context, tag: Optional[str]) -> None:
         """
         Append a tag at the beginning of the channel name.


### PR DESCRIPTION
This prevents it from showing up in the `help` command's output when it's not invoked in a thread.