### PR TITLE
Add the Mandatory Close Duration plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Modmail plugins for our Modmail bot, located at https://github.com/kyb3r/modmail
 ## List of plugins
 - **Ban appeals**: Threads created by users in a defined "appeal" guild get moved to a configured appeal category. This also both kicks users from the appeal guild when they rejoin the main guild, and kicks users from the appeal guild if they're not banned in the main guild.
 - **Close message:** Add a `?closemessage` command that will close the thread after 15 minutes with a default message.
-- **Mandatory Close Duration** Makes the `?close` command require a time duration when closing with a custom close message.
+- **Mandatory Close Duration** Makes the `?close` command require confirmation if a time duration isn't provided when closing with a custom close message.
 - **MDLink**: Generate a ready to paste link to the thread logs.
 - **Ping manager**: Delay pings by a configurable time period, cancel the ping task if a message is sent in the thread (Other than an author message).
 - **Reply cooldown**: Forbid you from sending the same message twice in ten seconds.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Modmail plugins for our Modmail bot, located at https://github.com/kyb3r/modmail
 ## List of plugins
 - **Ban appeals**: Threads created by users in a defined "appeal" guild get moved to a configured appeal category. This also both kicks users from the appeal guild when they rejoin the main guild, and kicks users from the appeal guild if they're not banned in the main guild.
 - **Close message:** Add a `?closemessage` command that will close the thread after 15 minutes with a default message.
+- **Mandatory Close Duration** Makes the `?close` command require a time duration when closing with a custom close message.
 - **MDLink**: Generate a ready to paste link to the thread logs.
 - **Ping manager**: Delay pings by a configurable time period, cancel the ping task if a message is sent in the thread (Other than an author message).
 - **Reply cooldown**: Forbid you from sending the same message twice in ten seconds.

--- a/mandatory_close_duration/mandatory_close_duration.py
+++ b/mandatory_close_duration/mandatory_close_duration.py
@@ -32,8 +32,12 @@ async def close_after_confirmation(ctx: commands.Context, converted_arg: time.Us
     try:
         await ctx.bot.wait_for('reaction_add', check=checkmark_press_check, timeout=5 * 60)
     except asyncio.TimeoutError:
-        await message.edit(content=message.content+'\n\n**Timed out.**')
-        await message.clear_reactions()
+        try:
+            await message.edit(content=message.content+'\n\n**Timed out.**')
+            await message.clear_reactions()
+        except discord.NotFound:
+            # The thread might have been closed by now.
+            pass
     else:
         await original_close_command(ctx, after=converted_arg)
 

--- a/mandatory_close_duration/mandatory_close_duration.py
+++ b/mandatory_close_duration/mandatory_close_duration.py
@@ -1,0 +1,67 @@
+from discord.ext import commands
+
+from bot import ModmailBot
+from core import time
+
+
+class StrictUserFriendlyDuration(time.UserFriendlyTime):
+    """
+    A converter which parses user-friendly time durations.
+
+    Since this converter is meant for parsing close messages while
+    closing threads, both custom close messages and time durations are
+    parsed.
+
+    Unlike the parent class, a time duration must be provided when
+    a custom close message is provided.
+    """
+
+    MODIFIERS = {'silently', 'silent', 'cancel'}
+
+    async def convert(self, ctx: commands.Context, argument: str) -> "StrictUserFriendlyDuration":
+        """
+        Parse the provided time duration along with any close message.
+
+        Fail if a custom close message is provided without a time
+        duration.
+        """
+        await super().convert(ctx, argument)
+
+        argument_passed = bool(argument)
+        not_a_modifier = argument not in self.MODIFIERS
+        if argument_passed and not_a_modifier and self.arg == argument:
+            # Fail since only a close message was provided.
+            raise commands.BadArgument("A time duration must be provided when closing with a custom message.")
+
+        return self
+
+
+ADDED_HELP_TEXT = '\n\n*Note: Providing a time duration is necessary when closing with a custom message.*'
+
+
+def setup(bot: ModmailBot) -> None:
+    """
+    Monkey patch the close command's callback.
+
+    This makes it use the StrictUserFriendlyTime converter and updates
+    the help text to reflect the new behaviour.
+    """
+    global previous_converter
+
+    command = bot.get_command('close')
+
+    previous_converter = command.callback.__annotations__['after']
+    command.callback.__annotations__['after'] = StrictUserFriendlyDuration
+    command.callback = command.callback
+
+    command.help += ADDED_HELP_TEXT
+
+
+def teardown(bot: ModmailBot) -> None:
+    """Undo changes to the close command."""
+    command = bot.get_command('close')
+
+    command.callback.__annotations__['after'] = previous_converter
+    command.callback = command.callback
+
+    command.help = command.help.remove_suffix(ADDED_HELP_TEXT)

--- a/mandatory_close_duration/mandatory_close_duration.py
+++ b/mandatory_close_duration/mandatory_close_duration.py
@@ -52,10 +52,20 @@ async def safe_close(
     """
     modifiers = {'silently', 'silent', 'cancel'}
 
-    argument_passed = bool(after)
-    not_a_modifier = after.arg not in modifiers
+    argument_passed = after is not None
 
-    if argument_passed and not_a_modifier and after.arg == after.raw:
+    if argument_passed:
+        not_a_modifier = after.arg not in modifiers
+
+        # These changes are always made to the argument by the super
+        # class so they need to be replicated before the raw argument
+        # is compared with the parsed message.
+        stripped_argument = after.raw.strip()
+        argument_without_phrases = stripped_argument.removeprefix('in ').removesuffix(' from now')
+
+        no_duration = after.arg == argument_without_phrases
+
+    if argument_passed and not_a_modifier and no_duration:
         # Ask for confirmation since only a close message was provided.
         await close_after_confirmation(ctx, after)
     else:


### PR DESCRIPTION
This makes the `?close` command require a time duration when closing with a custom close message. The close command in its current state abruptly closes the thread if you enter an incorrect time duration, for example.