### PR TITLE
Notify user leaves, kicks and joins in threads

### DIFF
--- a/ban_appeals/ban_appeals.py
+++ b/ban_appeals/ban_appeals.py
@@ -65,7 +65,7 @@ class BanAppeals(commands.Cog):
         for member in self.appeals_guild.members:
             await self._maybe_kick_user(member)
 
-    async def _maybe_kick_user(self, member: discord.Member) -> None:
+    async def _maybe_kick_user(self, member: discord.Member) -> bool:
         """
         Kick members joining appeals if they are not banned, and not part of the bypass list.
 
@@ -96,7 +96,7 @@ class BanAppeals(commands.Cog):
 
                 thread = await self.bot.threads.find(recipient=member)
                 if not thread:
-                    return
+                    return False
 
                 embed = discord.Embed(
                     description="The recipient joined the appeals server and has been autokicked.",


### PR DESCRIPTION
In its current state, the `on_member_join` and `on_member_remove` events don't use locks, so the order in which they execute isn't fixed. That can lead to a misleading order of messages. This PR changes that and improves the messages for different scenarios.

`_maybe_kick_user` is also refactored to return a boolean for whether the operation was successful.