### PR TITLE
enhance: make channel tag parameter a keyword-only arg 

### DIFF
--- a/tagging/tagging.py
+++ b/tagging/tagging.py
@@ -1,6 +1,5 @@
 from typing import Optional
 
-import discord
 from discord.ext import commands
 
 from bot import ModmailBot
@@ -30,12 +29,9 @@ class Tagging(commands.Cog):
         else:
             name = clean_name
 
-        embed = discord.Embed(
-            title=f"Tag `{tag}` applied successfully",
-            description="Changes may take up to 10 minutes to take effect.",
-            color=discord.Color.green(),
+        await ctx.reply(
+            "Changes may take up to 10 minutes to take effect due to rate-limits."
         )
-        await ctx.send(embed=embed)
         await ctx.channel.edit(name=name)
         await ctx.message.add_reaction("\u2705")
 

--- a/tagging/tagging.py
+++ b/tagging/tagging.py
@@ -17,7 +17,7 @@ class Tagging(commands.Cog):
     @commands.command()
     @commands.cooldown(2, 600, commands.BucketType.channel)
     @checks.thread_only()
-    async def tag(self, ctx: commands.Context, tag: Optional[str]) -> None:
+    async def tag(self, ctx: commands.Context, *, tag: Optional[str]) -> None:
         """
         Append a tag at the beginning of the channel name.
 

--- a/tagging/tagging.py
+++ b/tagging/tagging.py
@@ -15,6 +15,7 @@ class Tagging(commands.Cog):
 
     @checks.has_permissions(PermissionLevel.SUPPORTER)
     @commands.command()
+    @commands.cooldown(2, 600, commands.BucketType.channel)
     @checks.thread_only()
     async def tag(self, ctx: commands.Context, tag: Optional[str]) -> None:
         """

--- a/tagging/tagging.py
+++ b/tagging/tagging.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+import discord
 from discord.ext import commands
 
 from bot import ModmailBot
@@ -15,7 +16,6 @@ class Tagging(commands.Cog):
 
     @checks.has_permissions(PermissionLevel.SUPPORTER)
     @commands.command()
-    @commands.cooldown(2, 600, commands.BucketType.channel)
     @checks.thread_only()
     async def tag(self, ctx: commands.Context, *, tag: Optional[str]) -> None:
         """
@@ -30,6 +30,12 @@ class Tagging(commands.Cog):
         else:
             name = clean_name
 
+        embed = discord.Embed(
+            title=f"Tag `{tag}` applied successfully",
+            description="Changes may take up to 10 minutes to take effect.",
+            color=discord.Color.green(),
+        )
+        await ctx.send(embed=embed)
         await ctx.channel.edit(name=name)
         await ctx.message.add_reaction("\u2705")
 


### PR DESCRIPTION
Closes #22. Description in the issue.

screenshots:
<img width="324" alt="image" src="https://user-images.githubusercontent.com/37447267/157742513-84236181-9415-430a-8898-bd7ef11cda43.png">

<img width="176" alt="image" src="https://user-images.githubusercontent.com/37447267/157742570-fe42f854-2cb1-483c-96ce-bad943b77395.png">

update: As of https://github.com/python-discord/modmail-plugins/commit/db6b4bfc8036a75a51c65b79552aaa765169f106
<img width="450" alt="image" src="https://user-images.githubusercontent.com/37447267/159119484-dddd08e8-5d25-4a25-b5c5-3fc4fecb6c42.png">

