### PR TITLE
Move open modmail thread to ban appeals category when user joins appeals server

### DIFF
--- a/ban_appeals/ban_appeals.py
+++ b/ban_appeals/ban_appeals.py
@@ -156,12 +156,20 @@ class BanAppeals(commands.Cog):
             thread = await self.bot.threads.find(recipient=member)
             if not thread:
                 return
-
+            
+            category = await self.get_useable_appeal_category()
             embed = discord.Embed(
-                description="The recipient has joined the appeals server.",
+                description=f"Moving thread to `{category}` category since recipient has joined the appeals server.",
                 color=self.bot.mod_color
             )
             await thread.channel.send(embed=embed)
+
+            await thread.channel.move(
+                category=category,
+                end=True,
+                sync_permissions=True,
+                reason=f"{member} joined appeals server.",
+            )
 
     async def _handle_remove(self, member: discord.Member) -> None:
         """

--- a/ban_appeals/ban_appeals.py
+++ b/ban_appeals/ban_appeals.py
@@ -156,7 +156,7 @@ class BanAppeals(commands.Cog):
             thread = await self.bot.threads.find(recipient=member)
             if not thread:
                 return
-            
+
             category = await self.get_useable_appeal_category()
             embed = discord.Embed(
                 description=f"Moving thread to `{category}` category since recipient has joined the appeals server.",
@@ -240,7 +240,7 @@ class BanAppeals(commands.Cog):
     @checks.has_permissions(PermissionLevel.OWNER)
     @appeal_category_management.command(name="add")
     async def add_category(self, ctx: commands.Context, appeal_category: discord.CategoryChannel) -> None:
-        """Add a category to the list of ignored categories."""
+        """Add a category to the list of appeal categories."""
         if appeal_category.id in self.appeal_categories:
             await ctx.send(f":x: {appeal_category} already in the appeal category list.")
             return


### PR DESCRIPTION
I've tested the changes using the Bot Test Server as the main guild and my private test server as the appeals guild, and it works as expected (no screenshots because I closed the thread before I took any).

Second commit is a docstring fix unrelated to my changes.