### PR TITLE
fix: check category before moving to appeal category

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,9 +20,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Python Dependencies
-        uses: HassanAbouelela/actions/setup-python@setup-python_v1.3.2
+        uses: HassanAbouelela/actions/setup-python@setup-python_v1.6.0
         with:
-          dev: true
+          install_args: --no-root
           python_version: '3.9'
 
       # We will not run `flake8` here, as we will use a separate flake8
@@ -39,5 +39,6 @@ jobs:
       # Format used:
       # ::error file={filename},line={line},col={col}::{message}
       - name: Run flake8
-        run: "flake8 \
-        --format='::error file=%(path)s,line=%(row)d,col=%(col)d::[flake8] %(code)s: %(text)s'"
+        run: |
+          flake8 \
+          --format='::error file=%(path)s,line=%(row)d,col=%(col)d::[flake8] %(code)s: %(text)s'

--- a/ban_appeals/ban_appeals.py
+++ b/ban_appeals/ban_appeals.py
@@ -157,19 +157,22 @@ class BanAppeals(commands.Cog):
             if not thread:
                 return
 
-            category = await self.get_useable_appeal_category()
+            description = "The recipient has joined the appeals server."
+            if thread.channel.category.id not in self.appeal_categories:
+                category = await self.get_useable_appeal_category()
+                description = f"Thread moved to `{category}` category since recipient has joined the appeals server."
+                await thread.channel.move(
+                    category=category,
+                    end=True,
+                    sync_permissions=True,
+                    reason=f"{member} joined appeals server.",
+                )
+
             embed = discord.Embed(
-                description=f"Moving thread to `{category}` category since recipient has joined the appeals server.",
+                description=description,
                 color=self.bot.mod_color
             )
             await thread.channel.send(embed=embed)
-
-            await thread.channel.move(
-                category=category,
-                end=True,
-                sync_permissions=True,
-                reason=f"{member} joined appeals server.",
-            )
 
     async def _handle_remove(self, member: discord.Member) -> None:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "1.0.0"
 description = "A collection of modmail plugins for the Python Discord community."
 authors = ["Python Discord <info@pythondiscord.com>"]
 license = "MIT"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "3.9.*"


### PR DESCRIPTION
With PR #31, modmail threads are automatically moved to the ban appeal category if a user with an open thread gets banned and then joins the ban appeal server. The bot will also send an embed stating ""Moving thread to 📩｜Modmail Appeals category since recipient has joined the appeals server.""

However, currently, if a user who is actively appealing leaves and rejoins the ban appeal server,  the bot will send an embed stating "Moving thread to 📩｜Modmail Appeals category since recipient has joined the appeals server."- even if the user's modmail thread is already in the appeals category.

This PR will ensure that the bot will not attempt to move the thread to ban appeal category if it's already in the ban appeal category and also ensure that the correct message of "The recipient has joined the Appeals server" is sent.

I've tested the changes using the staff Bot Test Server as the main guild and my private test server as the appeals guild
![image](https://github.com/user-attachments/assets/fa41ac4b-43e6-45bc-a4f5-6571afeae1d5)


# Instructions for local testing:

1. I've never had any success trying to load [local plugins](https://docs.modmail.dev/usage-guide/plugins#local-for-developers), so I always load plugins from GitHub.
Fork  [our plugin repo](https://github.com/python-discord/modmail-plugins), switch to the `rejoin-appeal-category` branch, and update the guild ID in [this line](https://github.com/python-discord/modmail-plugins/blob/2b6c6d2c46732f7ad3ee71662b327e5c053af272/ban_appeals/ban_appeals.py#L19) to  your test appeal server's guild ID (this can be any server where both your bot and the account you're banning have access).

2. Clone the ModMail repo: 
```
git clone https://github.com/modmail-dev/Modmail
```

3. If you're using the staff Bot Test Server as the main server, you can use this as your `.env` file:
```
TOKEN=<your token>
LOG_URL=https://logviewername.herokuapp.com/
GUILD_ID=476190141161930753
MODMAIL_GUILD_ID=476190141161930753
OWNERS=476190391595433985
CONNECTION_URI=mongodb+srv://mongodburi
```

4. Start the bot:
```
cd Modmail
docker compose up
```

5. Run the following commands in discord:
```
?appeal_category_management add 1080759008748634162
```
(you can replace the category ID with the name of your appeal category if you're using a private test server as the main server)
```
?plugins add <your username>/modmail-plugins/ban_appeals@rejoin-appeal-category
```

