### PR TITLE
mdlink: Add option to send mobile-friendly link

### DIFF
--- a/mdlink/mdlink.py
+++ b/mdlink/mdlink.py
@@ -1,4 +1,7 @@
+import typing as t
+
 from discord.ext import commands
+from discord.utils import escape_markdown
 
 from bot import ModmailBot
 from core import checks
@@ -14,10 +17,19 @@ class MDLink(commands.Cog):
     @commands.command()
     @checks.has_permissions(PermissionLevel.MODERATOR)
     @checks.thread_only()
-    async def mdlink(self, ctx: commands.Context, *, text: str = "ModMail") -> None:
+    async def mdlink(
+        self,
+        ctx: commands.Context,
+        plain: t.Optional[t.Literal["plain", "p", "mobile", "m"]] = None,
+        *,
+        text: str = "ModMail",
+    ) -> None:
         """Return a link to the modmail thread in markdown syntax."""
         link = await self.bot.api.get_log_link(ctx.channel.id)
-        await ctx.send(f"`[{text}]({link})`")
+        if plain:
+            await ctx.send(escape_markdown(f"[{text}]({link})", as_needed=True, ignore_links=False))
+        else:
+            await ctx.send(f"`[{text}]({link})`")
 
 
 async def setup(bot: ModmailBot) -> None:


### PR DESCRIPTION
When copying a message on mobile, you have to copy the entire message anyways, and then you have to remove the backticks. This option allows the link to be sent escaped instead of in backticks, i.e.,

        \[foo](http://bar.com)

instead of

        `[foo](http://bar.com)`

<img width="609" alt="image" src="https://github.com/user-attachments/assets/6f02447a-d727-4c8e-a0ff-94826a590c20" />

----

Opinions?

- I currently don't escape the link itself (i.e., it remains clickable). I don't know if that's good or bad
- Thoughts on the wording? Currently you can use `m` or `mobile`, but it's really only tangentially related to being for mobile apps. `raw`/`r` (it's not really raw)? `escaped`/`e` (the default is _also_ escaped in a sense)?